### PR TITLE
SS6 compatibility: bump elemental-userforms to ^5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
         }
     ],
     "require": {
-        "dnadesign/silverstripe-elemental-userforms": "^4"
+        "dnadesign/silverstripe-elemental-userforms": "^5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^11",
         "friendsofphp/php-cs-fixer": "^3",
         "cambis/silverstripe-rector": "^2",
         "cambis/silverstan": "^2",


### PR DESCRIPTION
Update elemental-userforms constraint from ^4 to ^5 for SilverStripe 6 compatibility.